### PR TITLE
Fix/publish - prepare to be published on npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-build
+dist
 .idea
 .vscode
 coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+/.eslint*
+/.prettierrc.json
+/.vscode
+/coverage
+/jest.config.js
+/src
+/tsconfig.json
+/.github

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "install-peers": "install-peers",
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
+    "prepublishOnly": "tsc"
   },
   "devDependencies": {
     "@apollo/client": "^3.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2015",
     "module": "commonjs",
     "declaration": true,
-    "outDir": "./build",
+    "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
     "baseUrl": "./",
@@ -15,7 +15,7 @@
   },
   "exclude": [
     "node_modules",
-    "build",
-    "lib/**/*.test.ts",
+    "dist",
+    "__tests__",
   ]
 }


### PR DESCRIPTION
This PR fixes some configs preparing the lib to be published on npm

- fix outDir on tsconfig to match with main file on package.json
- add prepublishOnly script triggering a `tsc`
- fix dist/ dir on .gitignore and add a .npmignore